### PR TITLE
Hot Temp Fix

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -708,7 +708,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                             // Re-focus onto the holder so that users can click away
                             // from elements focused within the picker.
-                            P.$holder[0].focus()
+                            //P.$holder[0].focus()
                         }
                     }
                 }


### PR DESCRIPTION
To fix the calendar scroll issue in Calendar Picker.
In Small devices when the calendar available in scroll section then user not able to navigate to Prev and Next month.

https://github.com/ConnectedHomes/home-move/issues/1602
https://github.com/amsul/pickadate.js/issues/801
https://github.com/amsul/pickadate.js/issues/836

There is no impact to the application