### PR TITLE
Hotfix Temporary

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -702,14 +702,14 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                         //   prevent cases where focus is shifted onto external elements
                         //   when using things like jQuery mobile or MagnificPopup (ref: #249 & #120).
                         //   Also, for Firefox, don’t prevent action on the `option` element.
-                        if ( event.type == 'mousedown' && !$( target ).is( 'input, select, textarea, button, option' )) {
+                        /*if ( event.type == 'mousedown' && !$( target ).is( 'input, select, textarea, button, option' )) {
 
                             event.preventDefault()
 
                             // Re-focus onto the holder so that users can click away
                             // from elements focused within the picker.
                             P.$holder[0].focus()
-                        }
+                        }*/
                     }
                 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickadate",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "title": "pickadate.js",
   "description": "The mobile-friendly, responsive, and lightweight jQuery date & time input picker.",
   "keywords": [


### PR DESCRIPTION
Fix for Pickadate component scroll issue.
http://connectedhomes.github.io/ember-commons/#/pickadate-input

Forked the Pickadate plugin into ConnectedHomes Repo.

Affecting Mobile Browser Users having small screens.
https://github.com/ConnectedHomes/home-move/issues/1930

Related to this issue
https://github.com/ConnectedHomes/home-move/issues/1602
https://github.com/amsul/pickadate.js/issues/801
https://github.com/amsul/pickadate.js/issues/836

No New Test cases for this fix.
